### PR TITLE
Determinations improvements

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -955,9 +955,9 @@
       "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.53.3.tgz",
-      "integrity": "sha512-mRSi+4cBjrRLoaal2PnqH82Wqyb+d3HsPUN/W+WslCXsZsyHa9ZeQQX/pQsZaVIWDkPcpV6jJ+3KLbTbgnwv8w==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz",
+      "integrity": "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==",
       "cpu": [
         "arm"
       ],
@@ -969,9 +969,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.53.3.tgz",
-      "integrity": "sha512-CbDGaMpdE9sh7sCmTrTUyllhrg65t6SwhjlMJsLr+J8YjFuPmCEjbBSx4Z/e4SmDyH3aB5hGaJUP2ltV/vcs4w==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.59.0.tgz",
+      "integrity": "sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==",
       "cpu": [
         "arm64"
       ],
@@ -983,9 +983,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.53.3.tgz",
-      "integrity": "sha512-Nr7SlQeqIBpOV6BHHGZgYBuSdanCXuw09hon14MGOLGmXAFYjx1wNvquVPmpZnl0tLjg25dEdr4IQ6GgyToCUA==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.59.0.tgz",
+      "integrity": "sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==",
       "cpu": [
         "arm64"
       ],
@@ -997,9 +997,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.53.3.tgz",
-      "integrity": "sha512-DZ8N4CSNfl965CmPktJ8oBnfYr3F8dTTNBQkRlffnUarJ2ohudQD17sZBa097J8xhQ26AwhHJ5mvUyQW8ddTsQ==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.59.0.tgz",
+      "integrity": "sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==",
       "cpu": [
         "x64"
       ],
@@ -1011,9 +1011,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.53.3.tgz",
-      "integrity": "sha512-yMTrCrK92aGyi7GuDNtGn2sNW+Gdb4vErx4t3Gv/Tr+1zRb8ax4z8GWVRfr3Jw8zJWvpGHNpss3vVlbF58DZ4w==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.59.0.tgz",
+      "integrity": "sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==",
       "cpu": [
         "arm64"
       ],
@@ -1025,9 +1025,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.53.3.tgz",
-      "integrity": "sha512-lMfF8X7QhdQzseM6XaX0vbno2m3hlyZFhwcndRMw8fbAGUGL3WFMBdK0hbUBIUYcEcMhVLr1SIamDeuLBnXS+Q==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.59.0.tgz",
+      "integrity": "sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==",
       "cpu": [
         "x64"
       ],
@@ -1039,13 +1039,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.53.3.tgz",
-      "integrity": "sha512-k9oD15soC/Ln6d2Wv/JOFPzZXIAIFLp6B+i14KhxAfnq76ajt0EhYc5YPeX6W1xJkAdItcVT+JhKl1QZh44/qw==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.59.0.tgz",
+      "integrity": "sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1053,13 +1056,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.53.3.tgz",
-      "integrity": "sha512-vTNlKq+N6CK/8UktsrFuc+/7NlEYVxgaEgRXVUVK258Z5ymho29skzW1sutgYjqNnquGwVUObAaxae8rZ6YMhg==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.59.0.tgz",
+      "integrity": "sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1067,13 +1073,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.53.3.tgz",
-      "integrity": "sha512-RGrFLWgMhSxRs/EWJMIFM1O5Mzuz3Xy3/mnxJp/5cVhZ2XoCAxJnmNsEyeMJtpK+wu0FJFWz+QF4mjCA7AUQ3w==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.59.0.tgz",
+      "integrity": "sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1081,13 +1090,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.53.3.tgz",
-      "integrity": "sha512-kASyvfBEWYPEwe0Qv4nfu6pNkITLTb32p4yTgzFCocHnJLAHs+9LjUu9ONIhvfT/5lv4YS5muBHyuV84epBo/A==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.59.0.tgz",
+      "integrity": "sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1095,13 +1107,33 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.53.3.tgz",
-      "integrity": "sha512-JiuKcp2teLJwQ7vkJ95EwESWkNRFJD7TQgYmCnrPtlu50b4XvT5MOmurWNrCj3IFdyjBQ5p9vnrX4JM6I8OE7g==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.59.0.tgz",
+      "integrity": "sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==",
       "cpu": [
         "loong64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.59.0.tgz",
+      "integrity": "sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1109,13 +1141,33 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.53.3.tgz",
-      "integrity": "sha512-EoGSa8nd6d3T7zLuqdojxC20oBfNT8nexBbB/rkxgKj5T5vhpAQKKnD+h3UkoMuTyXkP5jTjK/ccNRmQrPNDuw==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.59.0.tgz",
+      "integrity": "sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.59.0.tgz",
+      "integrity": "sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1123,13 +1175,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.53.3.tgz",
-      "integrity": "sha512-4s+Wped2IHXHPnAEbIB0YWBv7SDohqxobiiPA1FIWZpX+w9o2i4LezzH/NkFUl8LRci/8udci6cLq+jJQlh+0g==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.59.0.tgz",
+      "integrity": "sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1137,13 +1192,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.53.3.tgz",
-      "integrity": "sha512-68k2g7+0vs2u9CxDt5ktXTngsxOQkSEV/xBbwlqYcUrAVh6P9EgMZvFsnHy4SEiUl46Xf0IObWVbMvPrr2gw8A==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.59.0.tgz",
+      "integrity": "sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1151,13 +1209,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.53.3.tgz",
-      "integrity": "sha512-VYsFMpULAz87ZW6BVYw3I6sWesGpsP9OPcyKe8ofdg9LHxSbRMd7zrVrr5xi/3kMZtpWL/wC+UIJWJYVX5uTKg==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.59.0.tgz",
+      "integrity": "sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1165,13 +1226,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.53.3.tgz",
-      "integrity": "sha512-3EhFi1FU6YL8HTUJZ51imGJWEX//ajQPfqWLI3BQq4TlvHy4X0MOr5q3D2Zof/ka0d5FNdPwZXm3Yyib/UEd+w==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1179,9 +1243,26 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.53.3.tgz",
-      "integrity": "sha512-eoROhjcc6HbZCJr+tvVT8X4fW3/5g/WkGvvmwz/88sDtSJzO7r/blvoBDgISDiCjDRZmHpwud7h+6Q9JxFwq1Q==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.59.0.tgz",
+      "integrity": "sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.59.0.tgz",
+      "integrity": "sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==",
       "cpu": [
         "x64"
       ],
@@ -1189,13 +1270,13 @@
       "license": "MIT",
       "optional": true,
       "os": [
-        "linux"
+        "openbsd"
       ]
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.53.3.tgz",
-      "integrity": "sha512-OueLAWgrNSPGAdUdIjSWXw+u/02BRTcnfw9PN41D2vq/JSEPnJnVuBgw18VkN8wcd4fjUs+jFHVM4t9+kBSNLw==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.59.0.tgz",
+      "integrity": "sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==",
       "cpu": [
         "arm64"
       ],
@@ -1207,9 +1288,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.53.3.tgz",
-      "integrity": "sha512-GOFuKpsxR/whszbF/bzydebLiXIHSgsEUp6M0JI8dWvi+fFa1TD6YQa4aSZHtpmh2/uAlj/Dy+nmby3TJ3pkTw==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.59.0.tgz",
+      "integrity": "sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==",
       "cpu": [
         "arm64"
       ],
@@ -1221,9 +1302,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.53.3.tgz",
-      "integrity": "sha512-iah+THLcBJdpfZ1TstDFbKNznlzoxa8fmnFYK4V67HvmuNYkVdAywJSoteUszvBQ9/HqN2+9AZghbajMsFT+oA==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.59.0.tgz",
+      "integrity": "sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==",
       "cpu": [
         "ia32"
       ],
@@ -1235,9 +1316,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.53.3.tgz",
-      "integrity": "sha512-J9QDiOIZlZLdcot5NXEepDkstocktoVjkaKUtqzgzpt2yWjGlbYiKyp05rWwk4nypbYUNoFAztEgixoLaSETkg==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==",
       "cpu": [
         "x64"
       ],
@@ -1249,9 +1330,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.53.3.tgz",
-      "integrity": "sha512-UhTd8u31dXadv0MopwGgNOBpUVROFKWVQgAg5N1ESyCz8AuBcMqm4AuTjrwgQKGDfoFuz02EuMRHQIw/frmYKQ==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.0.tgz",
+      "integrity": "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==",
       "cpu": [
         "x64"
       ],
@@ -2229,9 +2310,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.53.3.tgz",
-      "integrity": "sha512-w8GmOxZfBmKknvdXU1sdM9NHcoQejwF/4mNgj2JuEEdRaHwwF12K7e9eXn1nLZ07ad+du76mkVsyeb2rKGllsA==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
+      "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2245,28 +2326,31 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.53.3",
-        "@rollup/rollup-android-arm64": "4.53.3",
-        "@rollup/rollup-darwin-arm64": "4.53.3",
-        "@rollup/rollup-darwin-x64": "4.53.3",
-        "@rollup/rollup-freebsd-arm64": "4.53.3",
-        "@rollup/rollup-freebsd-x64": "4.53.3",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.53.3",
-        "@rollup/rollup-linux-arm-musleabihf": "4.53.3",
-        "@rollup/rollup-linux-arm64-gnu": "4.53.3",
-        "@rollup/rollup-linux-arm64-musl": "4.53.3",
-        "@rollup/rollup-linux-loong64-gnu": "4.53.3",
-        "@rollup/rollup-linux-ppc64-gnu": "4.53.3",
-        "@rollup/rollup-linux-riscv64-gnu": "4.53.3",
-        "@rollup/rollup-linux-riscv64-musl": "4.53.3",
-        "@rollup/rollup-linux-s390x-gnu": "4.53.3",
-        "@rollup/rollup-linux-x64-gnu": "4.53.3",
-        "@rollup/rollup-linux-x64-musl": "4.53.3",
-        "@rollup/rollup-openharmony-arm64": "4.53.3",
-        "@rollup/rollup-win32-arm64-msvc": "4.53.3",
-        "@rollup/rollup-win32-ia32-msvc": "4.53.3",
-        "@rollup/rollup-win32-x64-gnu": "4.53.3",
-        "@rollup/rollup-win32-x64-msvc": "4.53.3",
+        "@rollup/rollup-android-arm-eabi": "4.59.0",
+        "@rollup/rollup-android-arm64": "4.59.0",
+        "@rollup/rollup-darwin-arm64": "4.59.0",
+        "@rollup/rollup-darwin-x64": "4.59.0",
+        "@rollup/rollup-freebsd-arm64": "4.59.0",
+        "@rollup/rollup-freebsd-x64": "4.59.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.59.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.59.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.59.0",
+        "@rollup/rollup-linux-arm64-musl": "4.59.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.59.0",
+        "@rollup/rollup-linux-loong64-musl": "4.59.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.59.0",
+        "@rollup/rollup-linux-ppc64-musl": "4.59.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.59.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.59.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-musl": "4.59.0",
+        "@rollup/rollup-openbsd-x64": "4.59.0",
+        "@rollup/rollup-openharmony-arm64": "4.59.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.59.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.59.0",
+        "@rollup/rollup-win32-x64-gnu": "4.59.0",
+        "@rollup/rollup-win32-x64-msvc": "4.59.0",
         "fsevents": "~2.3.2"
       }
     },
@@ -2520,21 +2604,6 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/yaml": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
-      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      }
     }
   }
 }

--- a/client/src/components/ConfirmationModal.jsx
+++ b/client/src/components/ConfirmationModal.jsx
@@ -1,0 +1,102 @@
+import { useState } from 'react'
+import styled from '@emotion/styled'
+
+const ConfirmationModalContainer = styled.div`
+    z-index: 10000;
+    position: fixed;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+
+    display: flex;
+    justify-content: center;
+    align-items: center;
+
+    background-color: rgba(0, 0, 0, 0.1);
+
+    user-select: none;
+    -webkit-user-select: none;
+
+    .modal {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        grid-auto-rows: 1fr;
+        grid-column-gap: 15px;
+        grid-row-gap: 15px;
+
+        border: 1px solid #222;
+        border-radius: 5px;
+
+        padding: 20px;
+
+        background-color: white;
+
+        p {
+            grid-column: 1 / 3;
+
+            margin: 0px;
+
+            font-size: 12pt;
+
+            text-align: center;
+        }
+
+        button {
+            border: 1px solid gray;
+            border-radius: 5px;
+
+            padding: 5px;
+
+            background-color: white;
+
+            &:hover {
+                background-color: #efefef;
+            }
+        }
+
+        .confirm {
+            background-color: #c00;
+            color: white;
+
+            &:hover {
+                background-color: #ef0000;
+            }
+        }
+    }
+`
+
+// Pass in useState "modalEnabled" and "setModalEnabled",
+// "callback" to execute on clicking confirm,
+// modalText, confirmText (optional), cancelText (optional)
+export default function ConfirmationModal(props) {
+
+    const modalText = props.modalText || 
+        "Are you sure you wish to continue?"
+    const cancelText = props.cancelText || "Cancel"
+    const confirmText = props.confirmText || "Confirm"
+
+    // onKeyDown={(event) => { if (event.key === 'Escape') setShowLogoutModal(false) } }
+    return (
+        <>
+            { props.modalEnabled && 
+                <ConfirmationModalContainer>
+                    <div className='modal'>
+                        <p>{modalText}</p>
+
+                        <button onClick={(event) => {
+                            event.preventDefault()
+                            props.setModalEnabled(false)
+                        }}>{cancelText}</button>
+
+                        <button className='confirm' onClick={(event) => {
+                            event.preventDefault()
+                            props.callback()
+                            props.setModalEnabled(false)
+                        }}>{confirmText}</button>
+                    </div>
+                </ConfirmationModalContainer>
+            }
+        </>
+    )
+}

--- a/client/src/pages/determinations/DeterminationRow.jsx
+++ b/client/src/pages/determinations/DeterminationRow.jsx
@@ -44,9 +44,7 @@ export default function DeterminationRow({ row, unsubmitted, setUnsubmitted, aut
      * onFieldNumberChange()
      * Fills this row's fields with values from the matching occurrence, queried by field number
      */
-    // Would it have been possible to achieve this by just treating autofill
-    //  as a global instead of drilling it down into the QueriedSelections?
-    async function onFieldNumberChange(event, autofill) {
+    async function onFieldNumberChange(event) {
         const url = new URL('http://server/api/occurrences')
         const params = url.searchParams
         params.set('userLogin', volunteer)
@@ -216,7 +214,6 @@ export default function DeterminationRow({ row, unsubmitted, setUnsubmitted, aut
                     edited.current = true
                 }}
                 queryFn={fieldNumberQuery}
-                autofill={autofill}
                 onChange={onFieldNumberChange}
             />
             <p id={`sampleId${row}`}>{determination['sampleId']}</p>

--- a/client/src/pages/determinations/DeterminationRow.jsx
+++ b/client/src/pages/determinations/DeterminationRow.jsx
@@ -5,7 +5,7 @@ import QueriedSelection from './QueriedSelection.jsx'
 import { useAuth } from '../../AuthProvider.jsx'
 import { useFlow } from '../../FlowProvider'
 
-export default function DeterminationRow({ row, unsubmitted, setUnsubmitted }) {
+export default function DeterminationRow({ row, unsubmitted, setUnsubmitted, autofill }) {
     const blankDetermination = {
         // Handle 'fieldNumber' separately to avoid overwriting it
         '_id': '',
@@ -44,7 +44,9 @@ export default function DeterminationRow({ row, unsubmitted, setUnsubmitted }) {
      * onFieldNumberChange()
      * Fills this row's fields with values from the matching occurrence, queried by field number
      */
-    async function onFieldNumberChange(event) {
+    // Would it have been possible to achieve this by just treating autofill
+    //  as a global instead of drilling it down into the QueriedSelections?
+    async function onFieldNumberChange(event, autofill) {
         const url = new URL('http://server/api/occurrences')
         const params = url.searchParams
         params.set('userLogin', volunteer)
@@ -62,7 +64,8 @@ export default function DeterminationRow({ row, unsubmitted, setUnsubmitted }) {
 
             // If all taxonomy fields in this row are blank, try to copy down the values from the previous row
             const taxonomyFields = [ 'familyVolDet', 'genusVolDet', 'speciesVolDet', 'sexVolDet', 'casteVolDet' ]
-            if (taxonomyFields.every((field) => !newDetermination[field])) {
+            if (taxonomyFields.every((field) => !newDetermination[field])
+                && autofill) {
                 // For each taxonomy field, find the element in the previous row by ID
                 for (const field of taxonomyFields) {
                     const aboveElement = document.getElementById(`${field}${Math.max(row - 1, 0)}`)
@@ -213,6 +216,7 @@ export default function DeterminationRow({ row, unsubmitted, setUnsubmitted }) {
                     edited.current = true
                 }}
                 queryFn={fieldNumberQuery}
+                autofill={autofill}
                 onChange={onFieldNumberChange}
             />
             <p id={`sampleId${row}`}>{determination['sampleId']}</p>

--- a/client/src/pages/determinations/DeterminationsEditor.jsx
+++ b/client/src/pages/determinations/DeterminationsEditor.jsx
@@ -77,6 +77,7 @@ export default function DeterminationsEditor() {
     const [ unsubmitted, setUnsubmitted ] = useState(0)
     const [ result, setResult ] = useState()
     const [ panelKey, setPanelKey ] = useState(0)
+    const [ autofill, setAutofill ] = useState(true)
     const { setBlockLogOut } = useAuth()
 
     /* Blockers */
@@ -157,6 +158,8 @@ export default function DeterminationsEditor() {
                 disabled={disabled}
                 unsubmitted={unsubmitted}
                 result={result}
+                autofill={autofill}
+                setAutofill={(value) => setAutofill(value)}
                 onClear={() => {
                     setPanelKey(panelKey + 1)
                     setBlockLogOut(false)
@@ -167,6 +170,7 @@ export default function DeterminationsEditor() {
                 key={panelKey}
                 disabled={disabled}
                 unsubmitted={unsubmitted}
+                autofill={autofill}
                 setUnsubmitted={(value) => {
                     setUnsubmitted(value)
                     setBlockLogOut(!!value)

--- a/client/src/pages/determinations/DeterminationsEditor.jsx
+++ b/client/src/pages/determinations/DeterminationsEditor.jsx
@@ -177,8 +177,17 @@ export default function DeterminationsEditor() {
                 <div className='navBlockBackground'>
                     <div className='navBlockModal'>
                         <p>You have unsubmitted changes. Are you sure you want to leave?</p>
-                        <button onClick={() => blocker.proceed()}>Leave</button>
-                        <button onClick={() => blocker.reset()}>Stay</button>
+                        <button onClick={(event) => {
+                            // Doesn't seem strictly required in this case, but 
+                            //  I'm keeping it for consistency's sake
+                            event.preventDefault() 
+                            blocker.proceed()
+                        }}>Leave</button>
+                        <button onClick={(event) => {
+                            // Required to stop form submission
+                            event.preventDefault() 
+                            blocker.reset()
+                        }}>Stay</button>
                     </div>
                 </div>
             }

--- a/client/src/pages/determinations/DeterminationsHeader.jsx
+++ b/client/src/pages/determinations/DeterminationsHeader.jsx
@@ -1,5 +1,7 @@
-import { useRef } from 'react'
+import { useRef, useState } from 'react'
 import styled from '@emotion/styled'
+
+import ConfirmationModal from '../../components/ConfirmationModal'
 
 const DeterminationsHeaderContainer = styled.fieldset`
     display: flex;
@@ -53,20 +55,11 @@ const DeterminationsHeaderContainer = styled.fieldset`
     #clearButton {
         margin-left: auto;
     }
-    
-    #determinationsSubmitButton {
-        // background-color: royalblue;
-        // color: white;
-        //
-        // &:hover {
-        //     background-color: dodgerblue;
-        // }
-    }
-    
 `
 
 export default function DeterminationsHeader({ disabled, unsubmitted, result, onClear }) {
     const submitRef = useRef()
+    const [modalEnabled, setModalEnabled] = useState(false)
 
     return (
         <DeterminationsHeaderContainer disabled={disabled}>
@@ -88,9 +81,17 @@ export default function DeterminationsHeader({ disabled, unsubmitted, result, on
                 id='clearButton'
                 onClick={(event) => {
                     event.preventDefault()
-                    onClear()
+                    // onClear()
+                    setModalEnabled(true)
                 }}
             >Clear</button>
+
+            <ConfirmationModal 
+                modalEnabled={modalEnabled}
+                setModalEnabled={setModalEnabled}
+                callback={() => onClear()}
+                modalText="Are you sure you want to clear your work?"
+            />
         </DeterminationsHeaderContainer>
     )
 }

--- a/client/src/pages/determinations/DeterminationsHeader.jsx
+++ b/client/src/pages/determinations/DeterminationsHeader.jsx
@@ -8,7 +8,7 @@ const DeterminationsHeaderContainer = styled.fieldset`
     flex-direction: row;
     justify-content: start;
     align-items: center;
-    gap: 10px;
+    gap: 20px;
 
     border: 1px solid #222;
     border-radius: 5px;
@@ -57,7 +57,7 @@ const DeterminationsHeaderContainer = styled.fieldset`
     }
 `
 
-export default function DeterminationsHeader({ disabled, unsubmitted, result, onClear }) {
+export default function DeterminationsHeader({ disabled, unsubmitted, result, onClear, autofill, setAutofill }) {
     const submitRef = useRef()
     const [modalEnabled, setModalEnabled] = useState(false)
 
@@ -69,6 +69,13 @@ export default function DeterminationsHeader({ disabled, unsubmitted, result, on
                 ref={submitRef}
             >Submit</button>
 
+            <div>
+                <input type="checkbox" id="fill-toggle" 
+                    defaultChecked={autofill} onChange={e => {
+                        setAutofill(e.target.checked)
+                    }} />
+                <label htmlFor="fill-toggle">Enable fill-down</label>
+            </div>
 
             { !!unsubmitted &&
                 <p id='unsubmittedMessage'>{unsubmitted.toLocaleString('en-US')} unsubmitted changes pending...</p>
@@ -81,7 +88,6 @@ export default function DeterminationsHeader({ disabled, unsubmitted, result, on
                 id='clearButton'
                 onClick={(event) => {
                     event.preventDefault()
-                    // onClear()
                     setModalEnabled(true)
                 }}
             >Clear</button>

--- a/client/src/pages/determinations/DeterminationsHeader.jsx
+++ b/client/src/pages/determinations/DeterminationsHeader.jsx
@@ -49,6 +49,20 @@ const DeterminationsHeaderContainer = styled.fieldset`
             background-color: #efefef;
         }
     }
+
+    #clearButton {
+        margin-left: auto;
+    }
+    
+    #determinationsSubmitButton {
+        // background-color: royalblue;
+        // color: white;
+        //
+        // &:hover {
+        //     background-color: dodgerblue;
+        // }
+    }
+    
 `
 
 export default function DeterminationsHeader({ disabled, unsubmitted, result, onClear }) {
@@ -57,22 +71,26 @@ export default function DeterminationsHeader({ disabled, unsubmitted, result, on
     return (
         <DeterminationsHeaderContainer disabled={disabled}>
             <button
-                onClick={(event) => {
-                    event.preventDefault()
-                    onClear()
-                }}
-            >Clear</button>
-            <button
                 id='determinationsSubmitButton'
                 type='submit'
                 ref={submitRef}
             >Submit</button>
+
+
             { !!unsubmitted &&
                 <p id='unsubmittedMessage'>{unsubmitted.toLocaleString('en-US')} unsubmitted changes pending...</p>
             }
             { result &&
                 <p id='resultMessage'>{(result.matchedCount ?? 0).toLocaleString('en-US')} changes submitted</p>
             }
+
+            <button
+                id='clearButton'
+                onClick={(event) => {
+                    event.preventDefault()
+                    onClear()
+                }}
+            >Clear</button>
         </DeterminationsHeaderContainer>
     )
 }

--- a/client/src/pages/determinations/DeterminationsPanel.jsx
+++ b/client/src/pages/determinations/DeterminationsPanel.jsx
@@ -45,7 +45,7 @@ const DeterminationsPanelContainer = styled.fieldset`
     }
 `
 
-export default function DeterminationsPanel({ disabled, unsubmitted, setUnsubmitted }) {
+export default function DeterminationsPanel({ disabled, unsubmitted, setUnsubmitted, autofill }) {
     const [ rows, setRows ] = useState(Array.from(Array(50).keys()))
 
     const fields = [
@@ -70,8 +70,10 @@ export default function DeterminationsPanel({ disabled, unsubmitted, setUnsubmit
                 <DeterminationRow
                     key={row}
                     row={row}
+                    autofill={autofill}
                     unsubmitted={unsubmitted}
                     setUnsubmitted={setUnsubmitted}
+                    autofill={autofill}
                 />
             )}
         </DeterminationsPanelContainer>

--- a/client/src/pages/determinations/QueriedSelection.jsx
+++ b/client/src/pages/determinations/QueriedSelection.jsx
@@ -36,7 +36,7 @@ const QueriedSelectionContainer = styled.div`
     }
 `
 
-export default function QueriedSelection({ inputId, value = '', error, setValue, queryFn, onChange = null, autofill = true }) {
+export default function QueriedSelection({ inputId, value = '', error, setValue, queryFn, onChange = null }) {
     const [ timeoutId, setTimeoutId ] = useState()
     const [ options, setOptions ] = useState([])
 
@@ -67,7 +67,7 @@ export default function QueriedSelection({ inputId, value = '', error, setValue,
         const id = setTimeout(async () => {
             await queryOptions(event.target.value)
 
-            if (onChange) onChange(event, autofill)
+            if (onChange) onChange(event)
         }, queryDelayMSec)
         setTimeoutId(id)
     }
@@ -83,7 +83,7 @@ export default function QueriedSelection({ inputId, value = '', error, setValue,
                 list={`${inputId}Options`}
                 placeholder='Enter a query value...'
                 value={value}
-                onChange={(event) => handleChange(event, autofill)}
+                onChange={(event) => handleChange(event)}
                 onFocus={(event) => queryOptions(event.target.value)}
             />
             <datalist id={`${inputId}Options`}>

--- a/client/src/pages/determinations/QueriedSelection.jsx
+++ b/client/src/pages/determinations/QueriedSelection.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useContext } from 'react'
 import styled from '@emotion/styled'
 
 const QueriedSelectionContainer = styled.div`
@@ -36,7 +36,7 @@ const QueriedSelectionContainer = styled.div`
     }
 `
 
-export default function QueriedSelection({ inputId, value = '', error, setValue, queryFn, onChange = null }) {
+export default function QueriedSelection({ inputId, value = '', error, setValue, queryFn, onChange = null, autofill = true }) {
     const [ timeoutId, setTimeoutId ] = useState()
     const [ options, setOptions ] = useState([])
 
@@ -67,7 +67,7 @@ export default function QueriedSelection({ inputId, value = '', error, setValue,
         const id = setTimeout(async () => {
             await queryOptions(event.target.value)
 
-            if (onChange) onChange(event)
+            if (onChange) onChange(event, autofill)
         }, queryDelayMSec)
         setTimeoutId(id)
     }
@@ -83,7 +83,7 @@ export default function QueriedSelection({ inputId, value = '', error, setValue,
                 list={`${inputId}Options`}
                 placeholder='Enter a query value...'
                 value={value}
-                onChange={(event) => handleChange(event)}
+                onChange={(event) => handleChange(event, autofill)}
                 onFocus={(event) => queryOptions(event.target.value)}
             />
             <datalist id={`${inputId}Options`}>


### PR DESCRIPTION
This PR brings various improvements to the determinations page.

- The Navigation Blocker previously submitted the user's determinations when clicking "Stay", due to the event's default behavior not getting suppressed. This is now resolved.
- The clear button is moved to the right-most edge and opens a confirmation dialogue box upon being clicked, warning the user they're about to clear their work. Closes #3
- There's now a checkbox to enable the "fill-down" feature, which is enabled by default. Unchecking it prevents determinations from previous rows populating downwards. Closes #4 

Finally, this PR updates an unrelated package to avoid a Remote Code Execution vulnerability.