### PR TITLE
Fix and cache iNaturalist API token exchange

### DIFF
--- a/shared/lib/services/ApiService.js
+++ b/shared/lib/services/ApiService.js
@@ -12,27 +12,60 @@ class ApiService {
         this.backoffLimitMs = 8000
         this.defaultPageSize = 200
         this.iNaturalistApiToken = ''
+        this.iNaturalistApiTokenExpiresAt = 0
+    }
+
+    // Decode a JWT's 'exp' claim (as milliseconds since epoch) without verifying its signature
+    // Returns 0 if the token cannot be parsed
+    #getApiTokenExpiry(token) {
+        try {
+            const payload = token.split('.')[1]
+            const { exp } = JSON.parse(Buffer.from(payload, 'base64url').toString('utf8'))
+            return Number.isFinite(exp) ? exp * 1000 : 0
+        } catch {
+            return 0
+        }
     }
 
     async fetchINaturalistApiToken() {
-        // Read an OAuth access token from the local file
+        // iNaturalist API tokens are JWTs valid for ~24 hours; reuse the cached token until it nears
+        // expiration (60-second safety margin) instead of minting a new one on every request
+        if (this.iNaturalistApiToken && Date.now() < this.iNaturalistApiTokenExpiresAt - 60_000) {
+            return this.iNaturalistApiToken
+        }
+
+        // The cached token is missing or (nearly) expired; reset it before attempting to fetch a new one
+        this.iNaturalistApiToken = ''
+        this.iNaturalistApiTokenExpiresAt = 0
+
+        // Read the stored OAuth access token from the local file
         const { encryptedToken } = FileManager.readJSON(path.resolve('./shared/data/iNaturalistToken.json'), { encryptedToken: {} })
         const access_token = decryptObject(encryptedToken)
 
-        if (access_token) {
-            // Request a temporary API token from iNaturalist
-            const config = {
-                headers: { 'Authorization': `Bearer ${access_token}` }
-            }
-            
-            const response = await fetch('https://www.inaturalist.org/users/api_token', config)
-
-            if (response['content-type']?.includes('application/json')) {
-                const json = await response.json()
-                this.iNaturalistApiToken = json.api_token ?? ''
-            }
+        if (!access_token) {
+            console.error('No iNaturalist OAuth access token found; API requests will be unauthenticated')
+            return this.iNaturalistApiToken
         }
-        
+
+        // Exchange the OAuth access token for a temporary API token
+        try {
+            const response = await fetch('https://www.inaturalist.org/users/api_token', {
+                headers: { 'Authorization': `Bearer ${access_token}` }
+            })
+
+            if (!response.ok) {
+                console.error(`Failed to fetch iNaturalist API token: ${response.status} ${response.statusText}`)
+                return this.iNaturalistApiToken
+            }
+
+            const { api_token } = await response.json()
+            this.iNaturalistApiToken = api_token ?? ''
+            // Fall back to a conservative 12-hour lifetime if the expiration cannot be read from the token
+            this.iNaturalistApiTokenExpiresAt = this.#getApiTokenExpiry(this.iNaturalistApiToken) || (Date.now() + 12 * 60 * 60 * 1000)
+        } catch (error) {
+            console.error('Error while fetching iNaturalist API token:', error)
+        }
+
         return this.iNaturalistApiToken
     }
 


### PR DESCRIPTION
## Problem

Two issues in `ApiService.fetchINaturalistApiToken()` (`shared/lib/services/ApiService.js`) meant iNaturalist requests were effectively unauthenticated:

1. **Broken response check.** The token exchange guarded on `response['content-type']`, which is always `undefined` on a `fetch` `Response` — the header is at `response.headers.get('content-type')`. So `json.api_token` was never read and `this.iNaturalistApiToken` stayed `''`. Every observation/place/taxa request then went out without a `Bearer` token, forfeiting the higher authenticated rate limit and access to project-obscured coordinates.

2. **Re-minting on every request.** `fetchUrl()` calls `fetchINaturalistApiToken()` before each paged request, so a large observations sync makes thousands of extra calls to `inaturalist.org/users/api_token` just to mint throwaway tokens.

## Fix

- Check `response.ok` (with `status`/`statusText` logging on failure) and parse `api_token` from the JSON body.
- Cache the token on the singleton and reuse it until it nears expiry, decoding the JWT `exp` claim (with a conservative 12-hour fallback if it can't be read) and a 60-second safety margin.
- Log clearly when no stored OAuth access token is available.

## Why 24h caching is correct

iNaturalist API tokens are JWTs valid for ~24 hours, and the underlying OAuth access token does not expire (so there is nothing to refresh):

- `config/initializers/doorkeeper.rb`: `access_token_expires_in nil` and `grant_flows %w(authorization_code client_credentials password)` (no refresh-token flow).
- `lib/json_web_token.rb`: `def self.encode(payload, expiration = 24.hours.from_now)`.

## Testing

`node --check` passes. There is no test harness in the repo yet; happy to add one for this path if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)