### PR TITLE
Make observations/search date bounds inclusive-by-label (#22)

### DIFF
--- a/client/src/pages/dashboard/DashboardSearchPanel.jsx
+++ b/client/src/pages/dashboard/DashboardSearchPanel.jsx
@@ -365,7 +365,7 @@ export default function DashboardSearchPanel({ submitRef, disabled }) {
                     <img src={closeIcon} alt='Clear' />
                 </button>
 
-                <label>To</label>
+                <label>Through</label>
                 <input
                     id='maxDate'
                     type='date'
@@ -431,13 +431,13 @@ export default function DashboardSearchPanel({ submitRef, disabled }) {
                 }
                 { query.start_date &&
                     <button className='filterPill' onClick={(event) => handleClear(event, 'start_date')}>
-                        <p>Date &gt; {query.start_date}</p>
+                        <p>From {query.start_date}</p>
                         <img src={closeIcon} alt='Clear' />
                     </button>
                 }
                 { query.end_date &&
                     <button className='filterPill' onClick={(event) => handleClear(event, 'end_date')}>
-                        <p>Date &lt; {query.end_date}</p>
+                        <p>Through {query.end_date}</p>
                         <img src={closeIcon} alt='Clear' />
                     </button>
                 }

--- a/client/src/pages/tasks/SubtaskCardForm.jsx
+++ b/client/src/pages/tasks/SubtaskCardForm.jsx
@@ -142,11 +142,11 @@ export default function SubtaskCardForm({ type, taskState, pipelineState, setPip
                             <ProjectSelection />
                             
                             <div className='subtaskSetting'>
-                                <label htmlFor='minDate'>Minimum Date:</label>
+                                <label htmlFor='minDate'>From:</label>
                                 <input id='minDate' type='date' value={minDate} onChange={(e) => setMinDate(e.target.value)} required />
                             </div>
                             <div className='subtaskSetting'>
-                                <label htmlFor='maxDate'>Maximum Date:</label>
+                                <label htmlFor='maxDate'>Through:</label>
                                 <input id='maxDate' type='date' value={maxDate} onChange={(e) => setMaxDate(e.target.value)} required />
                             </div>
                         </>


### PR DESCRIPTION
Closes #22.

## What
Relabel the date-range bounds on the observations subtask and the dashboard search so they read as **inclusive**:

| Surface | Before | After |
|---|---|---|
| Observations subtask | Minimum Date / Maximum Date | **From: / Through:** |
| Dashboard search fields | From / To | **From / Through** |
| Dashboard filter pills | `Date > X` / `Date < X` | **From X / Through X** |

## Why
Per discussion on #22, "Minimum"/"Maximum" (and the dashboard's `>`/`<` pills) implied the maximum was exclusive, so users weren't sure same-day records were included.

Investigation confirmed the underlying query is **already inclusive on both ends** and timezone-correct:
- iNaturalist's `d1`/`d2`, when passed date-only (as this app does), match on the observation's local calendar date inclusively (verified against `iNaturalistAPI/lib/util.js`).
- The dashboard's stored `date` filter uses `$gte`/`$lte`.

So this is a **copy-only change** — no query logic touched. "Through" was chosen over "Not after" to fit the narrow dashboard label column while still reading as inclusive.

## Verified
Ran the full stack locally and confirmed all three surfaces render the new labels (subtask form, dashboard fields, and filter pills).