### PR TITLE
Document local development setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,43 @@
+# Copy to .env and fill in values before running `docker compose up`.
+# .env is gitignored. See "Local development" in README.md.
+#
+# Required variables are validated at startup by shared/lib/config/environment.js
+# (the server will refuse to boot if any are missing).
+
+# --- MongoDB root user -------------------------------------------------------
+# Enables auth on the mongo container and lets scripts/init-mongo.js run on the
+# first (empty-volume) startup.
+MONGO_INITDB_ROOT_USERNAME=root
+MONGO_INITDB_ROOT_PASSWORD=change-me
+MONGO_INITDB_DATABASE=api-backend
+
+# --- MongoDB application user (created by scripts/init-mongo.js) --------------
+# The server authenticates as this user against MONGO_AUTH_DB.
+MONGO_USER=obp
+MONGO_PASSWORD=change-me
+MONGO_DB=api-backend
+MONGO_AUTH_DB=api-backend
+MONGO_PORT=27017
+
+# --- Bootstrap admin account -------------------------------------------------
+# Seeded on server startup (server/src/index.js). Use these to log in as an
+# Administrator in the UI.
+ADMIN_USERNAME=admin
+ADMIN_PASSWORD=change-me
+
+# --- Secrets (required) ------------------------------------------------------
+# Generate with e.g. `openssl rand -hex 32`.
+JWT_SECRET=
+TOKEN_ENCRYPTION_SECRET=
+TOKEN_ENCRYPTION_SALT=
+
+# --- Client (Vite, read at build time from the repo root) --------------------
+VITE_VOLUNTEER_PASSWORD=change-me
+
+# --- Optional integrations (leave blank to disable) --------------------------
+# iNaturalist OAuth — only needed for the "log in with iNaturalist" token flow.
+INATURALIST_CLIENT_ID=
+INATURALIST_CLIENT_SECRET=
+INATURALIST_REDIRECT_URL=
+# Google Drive backups — only needed for the backup upload feature.
+GOOGLE_DRIVE_ID=

--- a/.gitignore
+++ b/.gitignore
@@ -110,6 +110,9 @@ web_modules/
 .env.production.local
 .env.local
 
+# Local docker-compose override (developer-specific, e.g. port remaps)
+docker-compose.local.yml
+
 # parcel-bundler cache (https://parceljs.org/)
 .cache
 .parcel-cache

--- a/README.md
+++ b/README.md
@@ -10,6 +10,22 @@ Orchestrated with Docker Compose ([`docker-compose.yml`](docker-compose.yml); de
 3. Build the client so nginx can serve it: `cd client && npm run build`, then open http://localhost/.
 4. Log in as an Administrator with the `ADMIN_USERNAME` / `ADMIN_PASSWORD` from your `.env` (seeded on startup).
 
+### First startup
+Everything under `shared/data/` is gitignored (see [`.gitignore`](.gitignore)), so a fresh clone has to recreate it. An Administrator login at melittologist.org can supply populated copies of the CSVs; empty files are enough to boot.
+
+1. Create the directories the subtasks write their output into:
+   ```
+   cd shared/data && mkdir -p addresses backups duplicates elevation emails flags labels observations occurrences pivots pulls reports taxonomy uploads
+   ```
+2. Create the seed and lookup files:
+   ```
+   touch workingOccurrences.csv backupOccurrences.csv plantList.csv usernames.csv
+   ```
+   - `workingOccurrences.csv` seeds the occurrences collection when the database is empty on startup ([`server/src/index.js`](server/src/index.js)).
+   - `usernames.csv` maps each occurrence's `userLogin` to a volunteer's contact info ([`shared/lib/services/UsernamesService.js`](shared/lib/services/UsernamesService.js)). Without it, every record from the Observations subtask gets a name error flag and never enters the occurrences collection.
+   - `plantList.csv` is the Oregon Bee Project plant list served by the plant-list endpoints. (The related iNaturalist taxonomy cache, `plantTaxa.json`, is created automatically.)
+3. **Optional — elevation data.** To fill the `elevation` field on pulled records, download 1-arc-second GeoTIFF tiles from the [USGS Earth Explorer](https://www.usgs.gov/faqs/where-can-i-get-global-elevation-data#faq) and unzip them into `shared/data/elevation/` ([`shared/lib/services/ElevationService.js`](shared/lib/services/ElevationService.js)). Skip this if you don't need elevation.
+
 ### Gotchas
 - **Port 443** is mapped for production TLS but unused in dev. If it collides on your machine, add a gitignored `docker-compose.local.yml` overriding the nginx ports and pass all three files to compose:
   ```yaml
@@ -22,4 +38,3 @@ Orchestrated with Docker Compose ([`docker-compose.yml`](docker-compose.yml); de
   ```
   docker compose -f docker-compose.yml -f docker-compose.override.yml -f docker-compose.local.yml up
   ```
-- **First startup** with an empty database seeds occurrences from `shared/data/workingOccurrences.csv`; create an empty file there if it's missing.

--- a/README.md
+++ b/README.md
@@ -19,10 +19,11 @@ Everything under `shared/data/` is gitignored (see [`.gitignore`](.gitignore)), 
    ```
 2. Create the seed and lookup files:
    ```
-   touch workingOccurrences.csv backupOccurrences.csv plantList.csv usernames.csv
+   touch workingOccurrences.csv backupOccurrences.csv plantList.csv
+   cp usernames.example.csv usernames.csv
    ```
    - `workingOccurrences.csv` seeds the occurrences collection when the database is empty on startup ([`server/src/index.js`](server/src/index.js)).
-   - `usernames.csv` maps each occurrence's `userLogin` to a volunteer's contact info ([`shared/lib/services/UsernamesService.js`](shared/lib/services/UsernamesService.js)). Without it, every record from the Observations subtask gets a name error flag and never enters the occurrences collection.
+   - `usernames.csv` maps each occurrence's `userLogin` to a volunteer's contact info ([`shared/lib/services/UsernamesService.js`](shared/lib/services/UsernamesService.js)). Without it, every record from the Observations subtask gets a name error flag and never enters the occurrences collection. [`usernames.example.csv`](shared/data/usernames.example.csv) is a two-row sample showing the format; replace it with a populated copy from an Administrator login at melittologist.org.
    - `plantList.csv` is the Oregon Bee Project plant list served by the plant-list endpoints. (The related iNaturalist taxonomy cache, `plantTaxa.json`, is created automatically.)
 3. **Optional — elevation data.** To fill the `elevation` field on pulled records, download 1-arc-second GeoTIFF tiles from the [USGS Earth Explorer](https://www.usgs.gov/faqs/where-can-i-get-global-elevation-data#faq) and unzip them into `shared/data/elevation/` ([`shared/lib/services/ElevationService.js`](shared/lib/services/ElevationService.js)). Skip this if you don't need elevation.
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,25 @@
 # OBP-Server
 A full stack web application that fetches bee observation data and creates specimen labels for the Oregon Bee Project
+
+## Stack
+Orchestrated with Docker Compose ([`docker-compose.yml`](docker-compose.yml); dev overrides in [`docker-compose.override.yml`](docker-compose.override.yml)): MongoDB, RabbitMQ, an Express API ([`server/`](server)), an R-based worker ([`worker/`](worker)), an nginx reverse proxy, and a Vite/React client ([`client/`](client)).
+
+## Local development
+1. Copy [`.env.example`](.env.example) to `.env` and fill it in (generate the secrets with `openssl rand -hex 32`). The server validates required variables at startup via [`shared/lib/config/environment.js`](shared/lib/config/environment.js).
+2. Start the backend: `docker compose up --build mongo rabbitmq server nginx`. (The full `docker compose up` additionally builds the R worker image — slow on the first run — and a Vite dev server at http://localhost:5173.)
+3. Build the client so nginx can serve it: `cd client && npm run build`, then open http://localhost/.
+4. Log in as an Administrator with the `ADMIN_USERNAME` / `ADMIN_PASSWORD` from your `.env` (seeded on startup).
+
+### Gotchas
+- **Port 443** is mapped for production TLS but unused in dev. If it collides on your machine, add a gitignored `docker-compose.local.yml` overriding the nginx ports and pass all three files to compose:
+  ```yaml
+  # docker-compose.local.yml
+  services:
+      nginx:
+          ports: !override
+              - '80:80'
+  ```
+  ```
+  docker compose -f docker-compose.yml -f docker-compose.override.yml -f docker-compose.local.yml up
+  ```
+- **First startup** with an empty database seeds occurrences from `shared/data/workingOccurrences.csv`; create an empty file there if it's missing.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Everything under `shared/data/` is gitignored (see [`.gitignore`](.gitignore)), 
 
 1. Create the directories the subtasks write their output into:
    ```
-   cd shared/data && mkdir -p addresses backups duplicates elevation emails flags labels observations occurrences pivots pulls reports taxonomy uploads
+   cd shared/data && mkdir -p addresses backups duplicates elevation emails flags labels mismatches observations occurrences pivots pulls reports taxonomy uploads
    ```
 2. Create the seed and lookup files:
    ```

--- a/shared/data/usernames.example.csv
+++ b/shared/data/usernames.example.csv
@@ -1,0 +1,3 @@
+userLogin,fullName,firstName,firstNameInitial,lastName,email,address,city,stateProvince,zipPostal,country
+rainhead,Peter Abrahamsen,Peter,P.,Abrahamsen,rainhead@gmail.com,7548 Ravenna Ave NE,Seattle,WA,98115-4662,USA
+njacobi,Nora Jacobi,Nora,N.,Jacobi,,,,,,


### PR DESCRIPTION
Adds developer onboarding docs, split out from the #22 label fix.

## What
- **`.env.example`** — enumerates every environment variable the stack uses, with comments distinguishing required (validated at startup by `shared/lib/config/environment.js`) from optional integrations. There was no template before, so a fresh clone couldn't boot without reverse-engineering the vars.
- **README "Local development" section** — startup steps plus two non-obvious gotchas: the unused `443` port mapping colliding on dev machines, and the first-boot `shared/data/workingOccurrences.csv` seed.
- **`.gitignore`** — ignore the developer-specific `docker-compose.local.yml` override referenced in the README.

## Notes
Discovered while bringing the stack up locally to verify #27. No application code changes.