### PR TITLE
Bound worker memory so OOM fails gracefully (#17)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -95,10 +95,15 @@ services:
             server:
                 condition: service_started
         restart: on-failure
+        # Cap the container's memory so a runaway subtask fails predictably instead of
+        # triggering the host's OOM killer. Keep the V8 heap (NODE_OPTIONS below) safely
+        # under this limit so Node throws a catchable error before the kernel steps in.
+        mem_limit: ${WORKER_MEM_LIMIT:-2g}
         env_file: ./.env
         environment:
             - MONGO_HOST=mongo
             - RABBITMQ_HOST=rabbitmq
+            - NODE_OPTIONS=--max-old-space-size=${WORKER_MAX_OLD_SPACE_MB:-1536}
         volumes:
             - ./worker/src:/app/src
             - ./shared:/app/shared


### PR DESCRIPTION
## Summary

Part 1 of 3 addressing #17 (memory-related crash in the Occurrences subtask). This PR is the small, independent **guardrail** — it does not change subtask logic; it makes an out-of-memory condition fail *predictably* instead of silently.

Today the worker container has no memory limit and no V8 heap limit. When a large Occurrences run exhausts memory, the host's Linux OOM killer reaps the worker process mid-task, so it can't record a failure or exit cleanly.

## Changes

- `mem_limit` on the `worker` service (default `2g`, override with `WORKER_MEM_LIMIT`).
- `NODE_OPTIONS=--max-old-space-size` (default `1536` MB, override with `WORKER_MAX_OLD_SPACE_MB`), deliberately set **below** the container limit so V8 throws a catchable `OOM` error before the kernel intervenes.

Rationale is documented inline in `docker-compose.yml`.

## Testing

- `docker compose config` validates and resolves both values (`mem_limit: 2147483648`, `NODE_OPTIONS: --max-old-space-size=1536`).
- Not yet run against a real >80k-record job — defaults are a starting point and may need tuning to the production host's RAM.

## Related PRs

The actual streaming fixes (the issue's "improve chunking" checkbox) follow in two separate PRs:
- Stream the observation-fetch → distinct-places/taxa pipeline (fixes the documented crash point).
- Stream the in-handler occurrence loops (`#indexOccurrences`, `#insertOccurrencesFromBeeIncreases`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)