### PR TITLE
Stream the Occurrences observation pipeline to avoid OOM (#17)

### DIFF
--- a/shared/lib/repositories/ObservationRepository.js
+++ b/shared/lib/repositories/ObservationRepository.js
@@ -36,4 +36,57 @@ export default class ObservationRepository extends BaseRepository {
     async findUnmatched() {
         return await this.findMany({ matched: false })
     }
+
+    /*
+     * distinctPlaceIds()
+     * Returns every distinct place ID referenced by observations matching the filter.
+     * Computed in the database so full observation documents never enter memory.
+     */
+    async distinctPlaceIds(filter = {}) {
+        const response = await this.aggregate([
+            { $match: { ...filter, place_ids: { $exists: true, $ne: null } } },
+            { $unwind: '$place_ids' },
+            { $group: { _id: '$place_ids' } }
+        ])
+
+        return response?.map((doc) => doc._id) ?? []
+    }
+
+    /*
+     * distinctTaxonIds()
+     * Returns every distinct taxon ID referenced by observations matching the filter, drawn
+     * from each taxon's ancestry (min_species_ancestry) and its synonymous taxon IDs. IDs are
+     * returned as strings to match the keys used in the local taxonomy data.
+     */
+    async distinctTaxonIds(filter = {}) {
+        const response = await this.aggregate([
+            { $match: { ...filter, taxon: { $exists: true, $ne: null } } },
+            {
+                $project: {
+                    ids: {
+                        $concatArrays: [
+                            {
+                                $cond: [
+                                    { $ifNull: [ '$taxon.min_species_ancestry', false ] },
+                                    { $split: [ '$taxon.min_species_ancestry', ',' ] },
+                                    []
+                                ]
+                            },
+                            {
+                                $map: {
+                                    input: { $ifNull: [ '$taxon.current_synonymous_taxon_ids', [] ] },
+                                    as: 'id',
+                                    in: { $toString: '$$id' }
+                                }
+                            }
+                        ]
+                    }
+                }
+            },
+            { $unwind: '$ids' },
+            { $group: { _id: '$ids' } }
+        ])
+
+        return response?.map((doc) => doc._id) ?? []
+    }
 }

--- a/shared/lib/services/ApiService.js
+++ b/shared/lib/services/ApiService.js
@@ -175,6 +175,43 @@ class ApiService {
         )
     }
 
+    /*
+     * fetchUrlByIdsChunks()
+     * Like fetchUrlByIds(), but yields each batch of results as it arrives instead of
+     * accumulating them all in memory. Callers that only pass the results through to the
+     * database can consume this with `for await` and never hold the full set at once.
+     */
+    async *fetchUrlByIdsChunks(buildUrl, pageSize, ids, updateProgress) {
+        await updateProgress(0)
+
+        // ids can be a very long list, so batch requests to avoid iNaturalist API refusal
+        const totalPages = Math.ceil(ids.length / pageSize)
+        let pageStart = 0
+        let pageEnd = Math.min(pageSize, ids.length)
+
+        for (let i = 0; i < totalPages; i++) {
+            const requestUrl = await buildUrl(ids.slice(pageStart, pageEnd).join(','))
+
+            const response = await this.fetchUrl(requestUrl)
+            yield response?.results ?? []
+
+            // Increment page
+            pageStart = pageEnd
+            pageEnd = Math.min(pageEnd + pageSize, ids.length)
+
+            await updateProgress(100 * (i + 1) / totalPages)
+        }
+    }
+
+    async *fetchObservationsByIdsChunks(observationIds, updateProgress) {
+        yield* this.fetchUrlByIdsChunks(
+            (ids) => `https://api.inaturalist.org/v1/observations?per_page=${200}&id=${ids}`,
+            200,
+            observationIds,
+            updateProgress
+        )
+    }
+
     async fetchPlacesByIds(placeIds, updateProgress) {
         return await this.fetchUrlByIds(
             (ids) => `https://api.inaturalist.org/v1/places/${ids}`,

--- a/shared/lib/services/ObservationService.js
+++ b/shared/lib/services/ObservationService.js
@@ -91,6 +91,14 @@ class ObservationService {
         return await this.repository.distinctCoordinates()
     }
 
+    async getDistinctPlaceIds(filter = {}) {
+        return await this.repository.distinctPlaceIds(filter)
+    }
+
+    async getDistinctTaxonIds(filter = {}) {
+        return await this.repository.distinctTaxonIds(filter)
+    }
+
     async getUnmatchedObservations() {
         return await this.repository.findUnmatched()
     }

--- a/shared/lib/services/PlacesService.js
+++ b/shared/lib/services/PlacesService.js
@@ -74,25 +74,21 @@ class PlacesService {
     }
 
     /*
-     * updatePlaces()
-     * Updates local place data from the given observations
+     * updatePlacesFromIds()
+     * Updates local place data from the given place IDs, fetching any not already known
      */
-    async updatePlacesFromObservations(observations, updateProgress) {
+    async updatePlacesFromIds(placeIds, updateProgress) {
         // Read place data
         this.readPlaces()
-    
-        // Compile a list of unknown places from the given observations
+
+        // Compile a list of unknown places from the given IDs
         const unknownPlaces = []
-        for (const observation of observations) {
-            const ids = observation.place_ids ?? []
-            
-            for (const id of ids) {
-                if (!(id in this.places) && !unknownPlaces.includes(id)) {
-                    unknownPlaces.push(id)
-                }
+        for (const id of placeIds ?? []) {
+            if (!(id in this.places) && !unknownPlaces.includes(id)) {
+                unknownPlaces.push(id)
             }
         }
-    
+
         // Fetch data for each unknown place from iNaturalist.org and combine it with the existing data
         if (unknownPlaces.length > 0) {
             const newPlaces = await ApiService.fetchPlacesByIds(unknownPlaces, updateProgress)
@@ -109,9 +105,24 @@ class PlacesService {
                 }
             }
         }
-    
+
         // Store the updated place data
         this.writePlaces()
+    }
+
+    /*
+     * updatePlacesFromObservations()
+     * Updates local place data from the place IDs referenced by the given observations
+     */
+    async updatePlacesFromObservations(observations, updateProgress) {
+        const placeIds = []
+        for (const observation of observations) {
+            for (const id of observation.place_ids ?? []) {
+                placeIds.push(id)
+            }
+        }
+
+        return await this.updatePlacesFromIds(placeIds, updateProgress)
     }
 }
 

--- a/shared/lib/services/PlantTaxaService.js
+++ b/shared/lib/services/PlantTaxaService.js
@@ -97,35 +97,25 @@ class PlantTaxaService {
     }
 
     /*
-     * updateTaxaFromObservations()
-     * Updates local taxonomy data from the given observations
+     * updateTaxaFromIds()
+     * Updates local taxonomy data from the given taxon IDs, fetching any not already known
      */
-    async updateTaxaFromObservations(observations, updateProgress) {
+    async updateTaxaFromIds(taxonIds, updateProgress) {
         // Read taxa data
         this.readTaxa()
-    
-        // Compile a list of unknown taxa from the given observations
+
+        // Compile a list of unknown taxa from the given IDs
         const unknownTaxa = []
-        for (const observation of observations) {
-            const ancestors = observation.taxon?.min_species_ancestry?.split(',') ?? []
-            const synonyms = observation.taxon?.current_synonymous_taxon_ids?.map((id) => id.toString()) ?? []
-    
-            for (const id of ancestors) {
-                if (!(id in this.taxa) && !unknownTaxa.includes(id)) {
-                    unknownTaxa.push(id)
-                }
-            }
-            for (const id of synonyms) {
-                if (!(id in this.taxa) && !unknownTaxa.includes(id)) {
-                    unknownTaxa.push(id)
-                }
+        for (const id of taxonIds ?? []) {
+            if (!(id in this.taxa) && !unknownTaxa.includes(id)) {
+                unknownTaxa.push(id)
             }
         }
-    
+
         // Fetch data for each unknown taxon from iNaturalist.org and combine it with the existing data
         if (unknownTaxa.length > 0) {
             const newTaxa = await ApiService.fetchTaxaByIds(unknownTaxa, updateProgress)
-    
+
             const savedRanks = ['phylum', 'order', 'family', 'genus', 'species']
             for (const newTaxon of newTaxa) {
                 if (savedRanks.includes(newTaxon.rank)) {
@@ -136,9 +126,25 @@ class PlantTaxaService {
                 }
             }
         }
-    
+
         // Store the updated taxonomy data
         this.writeTaxa()
+    }
+
+    /*
+     * updateTaxaFromObservations()
+     * Updates local taxonomy data from the taxon IDs referenced by the given observations
+     */
+    async updateTaxaFromObservations(observations, updateProgress) {
+        const taxonIds = []
+        for (const observation of observations) {
+            const ancestors = observation.taxon?.min_species_ancestry?.split(',') ?? []
+            const synonyms = observation.taxon?.current_synonymous_taxon_ids?.map((id) => id.toString()) ?? []
+
+            taxonIds.push(...ancestors, ...synonyms)
+        }
+
+        return await this.updateTaxaFromIds(taxonIds, updateProgress)
     }
 }
 

--- a/worker/src/handlers/OccurrencesSubtaskHandler.js
+++ b/worker/src/handlers/OccurrencesSubtaskHandler.js
@@ -258,28 +258,30 @@ export default class OccurrencesSubtaskHandler extends BaseSubtaskHandler {
         const observationIds = distinctUrls
             .map((url) => url.split('/').pop())
             .filter((id) => id && !isNaN(id))
-        // Fetch the observations corresponding to the uploaded occurrences and insert them into the observations database table
-        let matchingObservations = await ApiService.fetchObservationsByIds(observationIds, this.#createUpdateProgressFn(taskId))
-        // Set a custom field indicating that this observation has a matching occurrence
-        matchingObservations = matchingObservations.map((obs) => ({ ...obs, matched: true }))
 
-        // Insert observations into the database; delete old observations first
+        // Fetch the observations corresponding to the uploaded occurrences and insert them into the
+        // observations database table. Stream chunk-by-chunk so the full set is never held in memory
+        // at once, which could exhaust the worker on large inputs (issue #17).
         await ObservationService.deleteObservations()
-        if (matchingObservations.length > 0) {
-            await ObservationService.createObservations(matchingObservations)
+        for await (const chunk of ApiService.fetchObservationsByIdsChunks(observationIds, this.#createUpdateProgressFn(taskId))) {
+            // Set a custom field indicating that these observations have a matching occurrence
+            const matchingObservations = chunk.map((obs) => ({ ...obs, matched: true }))
+            if (matchingObservations.length > 0) {
+                await ObservationService.createObservations(matchingObservations)
+            }
         }
 
-        const observations = await ObservationService.getObservations()
-
-        // Update places.json and taxa.json from observations table
+        // Update places.json and taxa.json from the observations table. The distinct place and taxon
+        // IDs are computed in the database so full observation documents never enter memory.
         await TaskService.logTaskStep(taskId, 'Updating place data')
 
-        // Everything goes as expected here, nothing new. Followed by a crash.
-        await PlacesService.updatePlacesFromObservations(observations, this.#createUpdateProgressFn(taskId))
+        const placeIds = await ObservationService.getDistinctPlaceIds()
+        await PlacesService.updatePlacesFromIds(placeIds, this.#createUpdateProgressFn(taskId))
 
         await TaskService.logTaskStep(taskId, 'Updating taxonomy data')
 
-        await PlantTaxaService.updateTaxaFromObservations(observations, this.#createUpdateProgressFn(taskId))
+        const taxonIds = await ObservationService.getDistinctTaxonIds()
+        await PlantTaxaService.updateTaxaFromIds(taxonIds, this.#createUpdateProgressFn(taskId))
 
         // Query all distinct coordinates from the occurrences database table
         let coordinates = await OccurrenceService.getDistinctCoordinates({ scratch: true })


### PR DESCRIPTION
## Summary

Part 2 of 3 addressing #17. This is the **actual crash fix** — it targets the documented crash point in `OccurrencesSubtaskHandler.handleTask` (the `// Everything goes as expected here ... Followed by a crash.` comment).

On a large run (>80k records) the matched iNaturalist observations were held in memory **three times over**:
1. the full API result set accumulated by `fetchObservationsByIds`,
2. a second full copy from `.map(obs => ({ ...obs, matched: true }))`,
3. and a third when the whole `observations` collection was re-read via `getObservations()` purely to derive place and taxon IDs — held alive across *both* `updatePlacesFromObservations` and `updateTaxaFromObservations`.

## Changes

- **`ApiService.fetchObservationsByIdsChunks`** — an async generator that yields each API batch as it arrives (mirrors the existing `fetchObservationsBySourceChunks` pattern). The handler now inserts observations chunk-by-chunk and never holds the full set.
- **`ObservationRepository.distinctPlaceIds` / `distinctTaxonIds`** — MongoDB aggregations that derive the distinct place/taxon IDs to refresh, so full observation documents are no longer read back into the worker. `distinctTaxonIds` unions each taxon's `min_species_ancestry` (split) and `current_synonymous_taxon_ids`, returned as strings to match the local taxonomy keys.
- **`PlacesService.updatePlacesFromIds` / `PlantTaxaService.updateTaxaFromIds`** — the fetch-and-store logic, now keyed on IDs. The existing `*FromObservations` methods delegate to them, so the other callers (`ObservationsSubtaskHandler`, `PlantListSubtaskHandler`) are unchanged.

## Behavioral notes (batched observation inserts)

The observation insert changes from a single `createObservations(all)` to one `createObservations(chunk)` per API batch. The **successful-run result is identical**: batches request disjoint ID ranges, so no observation is fetched twice, and observations are inserted with auto-generated `_id`s, so there is no order-dependent dedup that a single call would resolve differently. Two things do change, both benign here:

1. **Partial-failure state.** If an insert errors mid-run, earlier chunks are already committed and later chunks are never attempted, so the partial DB state at the moment of failure differs from the old all-at-once insert. In both cases the task is marked failed and this scratch/intermediate data is cleared or overwritten on the next run, so there is no durable divergence.
2. **Incremental visibility.** Inserted observations become visible to any concurrent reader progressively rather than all at once. The original `insertMany` was not a transaction either, so no atomicity guarantee is lost — only the visibility window widens. Irrelevant under the worker's one-task-at-a-time model.

## Testing

- `node --check` passes on all six modified files.
- **No automated test suite exists in this repo**, so this has not been run end-to-end. Worth a manual run of an Occurrences subtask (ideally one large enough to have previously crashed) to confirm parity of `places.json` / `plantTaxa.json` output and the observations table before merge.

## Notes for review

- The distinct-ID aggregations are intended to reproduce exactly what the old in-memory loops collected (including that an empty `min_species_ancestry` yields a single `''` candidate ID, as before). Please sanity-check the aggregation logic against that intent.
- Independent of the other two #17 PRs; mergeable in any order.


## Verification (real-data parity test)

The distinct-ID aggregations were checked against main's exact in-memory loops using **real data**. 20 production occurrences' iNaturalist observation IDs were re-fetched from iNaturalist's public API (authentic nested `place_ids` / `taxon` structure), plus 6 synthetic edge-case docs (missing / empty / null `place_ids`, missing / null `taxon`, empty-string `min_species_ancestry`, numeric synonym IDs). Loaded into a throwaway MongoDB, the branch's `distinctPlaceIds` / `distinctTaxonIds` aggregations produced **byte-identical sets** to main's loops — place IDs 80 = 80, taxon IDs 109 = 109 — including the tricky empty-ancestry → `''` case and the numeric-synonym → string coercion, each confirmed individually.

(Implementation note: `mongosh`'s shell JS does not honor `?.` optional chaining, so main's loops were executed in real Node and only the aggregations ran in Mongo.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
