### PR TITLE
Stream the Occurrences indexing and bee-increase loops (#17)

### DIFF
--- a/worker/src/handlers/OccurrencesSubtaskHandler.js
+++ b/worker/src/handlers/OccurrencesSubtaskHandler.js
@@ -75,35 +75,59 @@ export default class OccurrencesSubtaskHandler extends BaseSubtaskHandler {
     async #insertOccurrencesFromBeeIncreases(updateProgress) {
         await updateProgress(0)
 
-        // Query observations with matching occurrences, keeping only one occurrence and the count of matching occurrences
-        const observations = await ObservationViewService.getObservationsWithOccurrences()
-        const occurrences = []
+        // Query the observation/occurrence join view page-by-page and insert new occurrences in
+        // batches, so neither the source observations nor the generated occurrences are ever all
+        // held in memory at once (issue #17). Inserting occurrences for one observation does not
+        // change any other observation's count (they join on distinct iNaturalist URLs), so the
+        // paginated view stays consistent as we go.
+        const flushSize = 5000
+        let pending = []
 
-        let i = 0
-        for (const observation of observations) {
-            const beesCollected = getOFV(observation.ofvs, ofvs.beesCollected)
+        let pageNumber = 1
+        let page = await ObservationViewService.getObservationViewPage(pageNumber)
+        const totalDocuments = page.pagination.totalDocuments
+        let processed = 0
 
-            if (beesCollected > observation.occurrenceCount) {
-                // Create new occurrences to make up the difference between the existing occurrences and the new number of bees collected
-                for (let j = 1; j < beesCollected - observation.occurrenceCount + 1; j++) {
-                    // Duplicate the first occurrence and set its SPECIMEN_ID
-                    const duplicateOccurrence = Object.assign({}, observation.firstOccurrence)
+        while (page.data.length > 0) {
+            for (const observation of page.data) {
+                const beesCollected = getOFV(observation.ofvs, ofvs.beesCollected)
 
-                    duplicateOccurrence[fieldNames.specimenId] = (observation.occurrenceCount + j).toString()
-                    // Clear OBSERVATION_NO and DATE_LABEL_PRINT fields so they can be assigned properly later
-                    duplicateOccurrence[fieldNames.fieldNumber] = ''
-                    duplicateOccurrence[fieldNames.dateLabelPrint] = ''
-                    // Tag the occurrence as new
-                    duplicateOccurrence.new = true
+                if (beesCollected > observation.occurrenceCount) {
+                    // Create new occurrences to make up the difference between the existing occurrences and the new number of bees collected
+                    for (let j = 1; j < beesCollected - observation.occurrenceCount + 1; j++) {
+                        // Duplicate the first occurrence and set its SPECIMEN_ID
+                        const duplicateOccurrence = Object.assign({}, observation.firstOccurrence)
 
-                    occurrences.push(duplicateOccurrence)
+                        duplicateOccurrence[fieldNames.specimenId] = (observation.occurrenceCount + j).toString()
+                        // Clear OBSERVATION_NO and DATE_LABEL_PRINT fields so they can be assigned properly later
+                        duplicateOccurrence[fieldNames.fieldNumber] = ''
+                        duplicateOccurrence[fieldNames.dateLabelPrint] = ''
+                        // Tag the occurrence as new
+                        duplicateOccurrence.new = true
+
+                        pending.push(duplicateOccurrence)
+                    }
                 }
+
+                // Flush the batch once it is large enough to keep memory bounded
+                if (pending.length >= flushSize) {
+                    await OccurrenceService.createOccurrences(pending, { scratch: true })
+                    pending = []
+                }
+
+                await updateProgress(totalDocuments ? 100 * (++processed) / totalDocuments : 100)
             }
 
-            await updateProgress(100 * (++i) / observations.length)
+            // Query the next page
+            page = await ObservationViewService.getObservationViewPage(++pageNumber)
         }
 
-        return await OccurrenceService.createOccurrences(occurrences, { scratch: true })
+        // Insert any remaining occurrences from the final partial batch
+        if (pending.length > 0) {
+            await OccurrenceService.createOccurrences(pending, { scratch: true })
+        }
+
+        await updateProgress(100)
     }
 
     /*
@@ -145,14 +169,16 @@ export default class OccurrencesSubtaskHandler extends BaseSubtaskHandler {
 
         nextFieldNumber = maxFieldNumber ? this.#incrementFieldNumber(maxFieldNumber) : nextFieldNumber
 
-        // Query occurrences page-by-page to avoid memory constraints
-        const updates = []
-        let pageNumber = 1
-        let results = await OccurrenceService.getUnindexedOccurrencesPage({ page: pageNumber, scratch: true })
-        while (pageNumber < results.pagination.totalPages + 1) {
+        // Index occurrences one page at a time, applying each page's updates before fetching the
+        // next. Assigning a field number removes an occurrence from the unindexed set, so we always
+        // drain the first page until none remain. This bounds memory to a single page rather than
+        // accumulating an update for every occurrence up front (issue #17). Occurrences are drained
+        // in composite_sort order, so field numbers are still assigned in the same sequence.
+        let results = await OccurrenceService.getUnindexedOccurrencesPage({ page: 1, scratch: true })
+        while (results.data.length > 0) {
             for (const occurrence of results.data) {
                 // Set field number, and if stateProvince is 'OR', set occurrenceId and resourceId
-                const updateDocument = { ...occurrence, observation: null }
+                const updateDocument = { observation: null }
 
                 updateDocument[fieldNames.fieldNumber] = nextFieldNumber
                 if (occurrence[fieldNames.stateProvince] === 'OR') {
@@ -161,17 +187,18 @@ export default class OccurrencesSubtaskHandler extends BaseSubtaskHandler {
                 }
 
                 const id = OccurrenceService.generateOccurrenceId(occurrence)
-                updates.push({ id, updateDocument })
+                await OccurrenceService.updateOccurrenceById(id, updateDocument)
                 nextFieldNumber = this.#incrementFieldNumber(nextFieldNumber)
             }
 
-            // Query the next page
-            results = await OccurrenceService.getUnindexedOccurrencesPage({ page: ++pageNumber, scratch: true })
-        }
+            // Re-query the first page; the occurrences just indexed have dropped out of the set
+            const previousTotal = results.pagination.totalDocuments
+            results = await OccurrenceService.getUnindexedOccurrencesPage({ page: 1, scratch: true })
 
-        for (const update of updates) {
-            const { id, updateDocument } = update
-            await OccurrenceService.updateOccurrenceById(id, updateDocument)
+            // Safety valve: bail out if a page failed to shrink the set rather than loop forever
+            if (results.pagination.totalDocuments >= previousTotal) {
+                throw new Error('Occurrence indexing did not converge; aborting to avoid an infinite loop')
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Part 3 of 3 addressing #17 — **hardening**. Two loops in `OccurrencesSubtaskHandler` built in-memory arrays that grow with the input size. Neither is the primary crash point (that's #35), but both add to memory pressure on large runs, so this converts them to bounded, streaming work.

## Changes

### `#indexOccurrences`
Previously paginated the *reads* but pushed an update for **every** unindexed occurrence into an `updates` array, then applied them all at the end — so the whole unindexed set was held in memory.

Now each page's updates are applied before the next page is fetched. Because assigning a field number removes an occurrence from the unindexed set, the loop repeatedly drains the **first** page until none remain (the same drain pattern already used in `OccurrenceRepository.updateMany`). Occurrences are still drained in `composite_sort` order, so **field numbers are assigned in exactly the same sequence as before**. A convergence guard throws rather than looping forever if a page ever fails to shrink the set.

The update document is also trimmed from `{ ...occurrence, observation: null, ... }` to just the changed fields. This is equivalent: `OccurrenceRepository.updateById` (line 321) rebuilds the `$set` as `{ ...updateDocument, composite_sort, date }`, so only the fields passed in are ever written, and `composite_sort`/`date` are recomputed from the full DB document either way.

### `#insertOccurrencesFromBeeIncreases`
Previously loaded the **entire** `observationsIJoinOccurrences` join view via `.toArray()` and buffered every generated occurrence before a single insert.

Now it pages through the view (`getObservationViewPage`) and flushes inserts in batches of 5000. `observationsIJoinOccurrences` is a live view (`viewOn: 'observations'` + `$lookup`), so correctness under concurrent inserts matters: inserting occurrences for one observation only changes **that** observation's `occurrenceCount` (the join is on distinct iNaturalist URLs), and never adds/removes observation documents or changes their `_id` order — so paginating by `_id` while inserting stays consistent, and each observation is still processed exactly once with its original count.

## Behavioral notes (batched writes)

Both loops now commit to Mongo incrementally instead of in a single call. The **successful-run result is identical** — the drained index updates land the same field numbers on the same records (same `composite_sort` order), and the generated bee-increase occurrences have disjoint `_id`s (hashed from a per-row `specimenId` plus URI), so batch boundaries never change which document inserts vs. is flagged a duplicate. Two things do change, both benign here:

1. **Partial-failure state.** If a write errors mid-run, earlier batches/pages are already committed and later ones are never attempted, so the partial DB state at the moment of failure differs from the old apply-all-at-end / single-insert approach. In both cases the task is marked failed and this scratch/intermediate data is cleared or overwritten on the next run, so there is no durable divergence.
2. **Incremental visibility.** Updated/inserted records become visible to any concurrent reader progressively rather than all at once. The original single insert was not a transaction either, so no atomicity guarantee is lost — only the visibility window widens. Irrelevant under the worker's one-task-at-a-time model.

## Testing

- `node --check` passes.
- **No automated test suite exists in this repo.** The indexing change in particular deserves a careful manual check that a run produces the identical `fieldNumber` / `occurrenceId` / `resourceId` assignments as `main` (the equivalence argument above is the thing to verify). A large run is the meaningful test for the memory behavior.

## Notes for review

- The two loops are independent of each other and of the other two #17 PRs; mergeable in any order.
- Trade-off to weigh: paginating the live view re-runs its `$lookup` per page (skip-based), which is more total DB work than the previous single pass, in exchange for bounded memory. Happy to switch to cursor-streaming if you'd prefer to avoid that.


## Verification (real-data parity test — `#indexOccurrences`)

main's accumulate-then-apply loop and the branch's drain loop were run against **real data** and compared. 143 complete production occurrences (Oregon Bee Atlas) were put into the pre-index state, plus synthetic variants covering every branch: cleared vs. preserved `occurrenceID` / `resourceID`, non-OR docs, `errorFlags`-excluded docs, and a pre-indexed doc to drive the `maxFieldNumber` continuation. Both loop bodies — copied verbatim, both calling verbatim copies of the real repository primitives (`setSortField` / `setDateField` / `generateOccurrenceId` / `updateById` / paginate) — ran against identically-seeded collections in a throwaway MongoDB with `pageSize=10` to force **14 pages**.

Result: **zero mismatches** across all 144 docs on `fieldNumber` / `occurrenceID` / `resourceID`; both indexed the same 136 and excluded the same 8, with new field numbers continuing contiguously from the pre-existing max. This confirms the drain assigns identical field numbers precisely *because* indexing a record removes it from the unindexed set before its recomputed `composite_sort` (which now includes the new `fieldNumber`) can reorder anything.

### `#insertOccurrencesFromBeeIncreases` verification

Reproducing the `observationsIJoinOccurrences` view with real data revealed that **this step is currently a no-op in production**, for two pre-existing reasons in `DatabaseManager.createViews` (tracked separately in #38): the view's final `$match` references `occurrencesCount` while the projection produces `occurrenceCount`, so the view always returns 0 rows; and the inclusion projection drops `ofvs`, so `beesCollected` is always empty even if that typo is fixed. This change is therefore behavior-preserving by construction — a no-op paginated is still a no-op.

The streaming logic itself was still validated: against a **fully-repaired** view (correct spelling + `ofvs` projected), with real observations forced to have bee increases, the original whole-view-then-single-insert approach and this branch's paginate-and-batch-insert approach produced an **identical set of 40 new occurrences** across 4 view pages with batch inserts interleaved with the paginated reads — confirming the URI-disjointness argument (inserting occurrences mid-pagination does not corrupt later pages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

