### PR TITLE
Ignore local-only Docker Compose overrides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,6 +111,10 @@ web_modules/
 .env.production.local
 .env.local
 
+# Local-only Docker Compose overrides (personal, not committed)
+docker-compose.local.yml
+docker-compose.*.local.yml
+
 # parcel-bundler cache (https://parceljs.org/)
 .cache
 .parcel-cache


### PR DESCRIPTION
## Summary

Adds `.gitignore` rules for local-only Docker Compose override files — `docker-compose.local.yml` and the more general `docker-compose.*.local.yml`:

```
docker-compose.local.yml
docker-compose.*.local.yml
```

These are personal, machine-specific overrides that a developer creates locally (for example, remapping a port that collides with something else on their host). They are not tracked in the repo and shouldn't be — but with no ignore rule, they're easy to commit by accident via a broad `git add`. This adds the rules proactively so that never happens.

Both lines are needed: `docker-compose.*.local.yml` alone does not match `docker-compose.local.yml`, because there's no segment between `compose.` and `.local`.

## Testing

- `git check-ignore` confirms both `docker-compose.local.yml` and e.g. `docker-compose.foo.local.yml` are matched by the new rules.

Independent of the #17 PRs; this is repo hygiene.

🤖 Generated with [Claude Code](https://claude.com/claude-code)