### PR TITLE
Add sort option for dateLabelPrint

### DIFF
--- a/client/src/pages/dashboard/DashboardResultsHeader.jsx
+++ b/client/src/pages/dashboard/DashboardResultsHeader.jsx
@@ -151,6 +151,7 @@ export default function DashboardResultsHeader({ handleEnter, disabled }) {
                 >
                     <option value='fieldNumber'>fieldNumber</option>
                     <option value='date'>date</option>
+                    <option value='dateLabelPrint'>dateLabelPrint</option>
                 </select>
                 <select
                     id='sortDir'

--- a/shared/lib/utils/utilities.js
+++ b/shared/lib/utils/utilities.js
@@ -144,14 +144,18 @@ function parseQueryParameters(query, adminId) {
     }
 
     // Sorting parameters
+    const sortDirection = query.sort_dir === 'desc' ? -1 : 1
     if (query.sort_by === 'fieldNumber') {
-        const direction = query.sort_dir === 'desc' ? -1 : 1
-        params.sortConfig = [ { field: 'composite_sort', direction } ]
+        params.sortConfig = [ { field: 'composite_sort', direction: sortDirection } ]
     } else if (query.sort_by === 'date') {
-        const direction = query.sort_dir === 'desc' ? -1 : 1
         // Sort by date, then default
         params.sortConfig = [
-            { field: 'date', direction },
+            { field: 'date', direction: sortDirection },
+            { field: 'composite_sort', direction: 1 }
+        ]
+    } else if (query.sort_by === 'dateLabelPrint') {
+        params.sortConfig = [
+            { field: 'dateLabelPrint', direction: sortDirection },
             { field: 'composite_sort', direction: 1 }
         ]
     }


### PR DESCRIPTION
## Description
Work-in progress support for adding `dateLabelPrint` as a sort option on the dashboard (closes #40). Note that if issue #41 is implemented prior to this PR, all changes in `client/src/pages/dashboard/DashboardResultsHeader.jsx` can be disregarded.

## To-do
- [x] Add front-end option for sorting by `dateLabelPrint`
- [x] Support new sort option in middleware
- [ ] Restructure `dateLabelPrint` as a proper date object so it can be sorted correctly