### PR TITLE
Convert shared/lib/utils to TypeScript

### DIFF
--- a/shared/lib/utils/constants.ts
+++ b/shared/lib/utils/constants.ts
@@ -601,7 +601,9 @@ const constants = {
             'Franklin , US, WA': 'Franklin'
         }
     }
-}
+// `as const` makes every value a precise literal type and readonly, so
+// TypeScript can catch typos like fieldNames.feildNumber at compile time.
+} as const
 
 export const { fileLimits } = constants
 export const { auth } = constants

--- a/shared/lib/utils/errors.ts
+++ b/shared/lib/utils/errors.ts
@@ -1,12 +1,12 @@
 export class InvalidArgumentError extends Error {
-    constructor(message) {
+    constructor(message?: string) {
         super(message)
         this.name = 'InvalidArgumentError'
     }
 }
 
 export class ValidationError extends Error {
-    constructor(message) {
+    constructor(message?: string) {
         super(message)
         this.name = 'ValidationError'
     }

--- a/shared/lib/utils/utilities.test.ts
+++ b/shared/lib/utils/utilities.test.ts
@@ -77,16 +77,7 @@ describe('parseQueryParameters', () => {
 
     const ADMIN_ID = '64ff0a2b7c1e4d5a6b7c8d9e'
 
-    // tsc infers parseQueryParameters' return type from its initial object
-    // literal in utilities.js, which doesn't include the conditionally-added
-    // `error` field. Until that file is converted to TypeScript, widen the
-    // type here at the test boundary.
-    type ParsedQuery = ReturnType<typeof parseQueryParameters> & {
-        error?: { status: number; message: string }
-        filter: Record<string, unknown>
-    }
-    const parse = (query: Record<string, string>, adminId?: string) =>
-        parseQueryParameters(query, adminId) as ParsedQuery
+    const parse = parseQueryParameters
 
     it('applies default pagination', () => {
         const params = parse({}, ADMIN_ID)

--- a/shared/lib/utils/utilities.ts
+++ b/shared/lib/utils/utilities.ts
@@ -4,11 +4,37 @@ import { fieldNames, subtasks as subtasksConstant } from './constants.js'
 import { tokens } from '../config/environment.js'
 import { InvalidArgumentError, ValidationError } from './errors.js'
 
+// API query parameters as Express provides them: every value a string, or
+// absent. (Query values can technically also be arrays; this code has always
+// treated them as strings.)
+type QueryParameters = Record<string, string | undefined>
+
+interface SortField {
+    field: string
+    direction: 1 | -1
+    type?: string
+}
+
+export interface ParsedQueryParameters {
+    page: number
+    pageSize: number
+    filter: { date?: { $gte?: Date; $lte?: Date } } & Record<string, unknown>
+    projection: Record<string, 0 | 1>
+    sortConfig: SortField[]
+    error?: { status: number; message: string }
+}
+
+export interface EncryptedObject {
+    iv: string
+    authTag: string
+    data: string
+}
+
 /*
  * includesIllegalSuffix()
  * A boolean function that returns whether a given string contains a street suffix (Road, Rd, Street, St, etc.)
  */
-function includesIllegalSuffix(string) {
+function includesIllegalSuffix(string: unknown): boolean {
     if (!string || typeof string !== 'string') { return false }
     // A list of RegExps to detect street suffixes
     const streetSuffixRegexes = [
@@ -29,13 +55,13 @@ function includesIllegalSuffix(string) {
  * getDayOfYear()
  * Calculates the day of the year (1 - 366) of a given Date object
  */
-function getDayOfYear(date) {
-    if (!(date instanceof Date) || isNaN(date)) {
+function getDayOfYear(date: Date): number | undefined {
+    if (!(date instanceof Date) || isNaN(date.getTime())) {
         return
     }
 
     const startDate = new Date(date.getFullYear(), 0, 0)
-    const dateDifference = date - startDate
+    const dateDifference = date.getTime() - startDate.getTime()
     const dayMilliseconds = 1000 * 60 * 60 * 24
     return Math.floor(dateDifference / dayMilliseconds)
 }
@@ -44,7 +70,7 @@ function getDayOfYear(date) {
  * delay()
  * Returns a Promise that resolves after a given number of milliseconds
  */
-function delay(mSec) {
+function delay(mSec: number): Promise<void> {
     return new Promise(resolve => setTimeout(resolve, mSec))
 }
 
@@ -52,7 +78,10 @@ function delay(mSec) {
  * getOFV()
  * Looks up the value of an iNaturalist observation field by name
  */
-function getOFV(ofvs, fieldName) {
+function getOFV(
+    ofvs: { name: string; value?: string | number | null }[] | undefined,
+    fieldName: string
+): string | number {
     const ofv = ofvs?.find((field) => field.name === fieldName)
     return ofv?.value ?? ''
 }
@@ -61,8 +90,8 @@ function getOFV(ofvs, fieldName) {
  * parseQueryParameters()
  * Parses API query parameters into a valid database query
  */
-function parseQueryParameters(query, adminId) {
-    const params = {
+function parseQueryParameters(query: QueryParameters, adminId?: string): ParsedQueryParameters {
+    const params: ParsedQueryParameters = {
         page: 1,
         pageSize: 50,
         filter: {},
@@ -92,12 +121,12 @@ function parseQueryParameters(query, adminId) {
     }
 
     // Pagination parameters
-    const parsedPage = parseInt(query.page)
+    const parsedPage = parseInt(query.page ?? '')
     if (query.page && !isNaN(parsedPage)) {
         params.page = parsedPage
     }
 
-    const parsedPerPage = parseInt(query.per_page)
+    const parsedPerPage = parseInt(query.per_page ?? '')
     if (query.per_page && !isNaN(parsedPerPage)) {
         params.pageSize = Math.min(parsedPerPage, 5000)     // Limit page size to 5000
     }
@@ -113,32 +142,31 @@ function parseQueryParameters(query, adminId) {
         return params
     }
     if (startDate.toString() !== 'Invalid Date') {
-        if (!params.filter.date) params.filter.date = {}
-        
         // Set time to noon UTC to avoid location-based date variance
         startDate.setHours(12, 0, 0, 0)
-        params.filter.date.$gte = startDate
+        params.filter.date = { ...params.filter.date, $gte: startDate }
     }
     if (endDate.toString() !== 'Invalid Date') {
-        if (!params.filter.date) params.filter.date = {}
-
         // Set time to noon UTC to avoid location-based date variance
         endDate.setHours(12, 0, 0, 0)
-        params.filter.date.$lte = endDate
+        params.filter.date = { ...params.filter.date, $lte: endDate }
     }
 
     // Parse field names directly included in the query object
     const queryFields = Object.values(fieldNames).filter((fieldName) => !!query[fieldName] || query[fieldName] === '')
     for (const queryField of queryFields) {
-        if (query[queryField] === '(empty)') {
+        const value = query[queryField]
+        if (value === undefined) continue   // can't happen (filtered above); narrows the type
+
+        if (value === '(empty)') {
             // The query value '(empty)' is reserved for empty value queries
             params.filter[queryField] = { $in: [ null, '' ] }
-        } else if (query[queryField] === '(non-empty)') {
+        } else if (value === '(non-empty)') {
             // The query value '(non-empty)' is reserved for non-empty value queries
             params.filter[queryField] = { $exists: true, $nin: [ null, '' ] }
         } else {
             // Comma-separated multi-value queries (case insensitive)
-            const regexes = query[queryField].split(',').map((value) => new RegExp(`^${value}$`, 'i'))
+            const regexes = value.split(',').map((value) => new RegExp(`^${value}$`, 'i'))
             params.filter[queryField] = { $in: regexes }
         }
     }
@@ -165,7 +193,9 @@ function parseQueryParameters(query, adminId) {
  * parseSubtasks()
  * Parses subtasks from a given JSON string, throwing errors if any fields are invalid
  */
-function parseSubtasks(subtasksJSON, adminId) {
+// Subtasks arrive as client-supplied JSON, so JSON.parse can only give `any`;
+// a validated subtask type can come once task handling is converted.
+function parseSubtasks(subtasksJSON: string | undefined, adminId?: string): any[] {
     if (!subtasksJSON) { throw new InvalidArgumentError('subtasks must exist') }
     
     try {
@@ -211,7 +241,9 @@ function parseSubtasks(subtasksJSON, adminId) {
 
         return subtasks
     } catch (error) {
-        if (error.message?.search('JSON.parse') !== -1) {   // Catch JSON parsing errors
+        // Known bug (#45): modern SyntaxError messages don't contain
+        // 'JSON.parse', so malformed JSON escapes as a raw SyntaxError.
+        if (error instanceof Error && error.message?.search('JSON.parse') !== -1) {   // Catch JSON parsing errors
             throw new ValidationError('Invalid JSON in subtasks')
         } else {
             throw error
@@ -222,7 +254,7 @@ function parseSubtasks(subtasksJSON, adminId) {
 const ALGORITHM = 'aes-256-gcm'
 const KEY = Crypto.scryptSync(tokens.secret, tokens.salt, 32)
 
-function encryptObject(object) {
+function encryptObject(object: unknown): EncryptedObject {
     const iv = Crypto.randomBytes(16)
     const cipher = Crypto.createCipheriv(ALGORITHM, KEY, iv)
 
@@ -240,18 +272,19 @@ function encryptObject(object) {
     }
 }
 
-function decryptObject(encryptedObject) {
+function decryptObject(encryptedObject: Partial<EncryptedObject> | null | undefined): any {
     if (!encryptedObject || !encryptedObject.iv || !encryptedObject.authTag || !encryptedObject.data) return
+    const { iv, authTag, data } = encryptedObject
 
     const decipher = Crypto.createDecipheriv(
         ALGORITHM,
         KEY,
-        Buffer.from(encryptedObject.iv, 'hex')
+        Buffer.from(iv, 'hex')
     )
-    decipher.setAuthTag(Buffer.from(encryptedObject.authTag, 'hex'))
+    decipher.setAuthTag(Buffer.from(authTag, 'hex'))
 
     const decrypted = Buffer.concat([
-        decipher.update(Buffer.from(encryptedObject.data, 'hex')),
+        decipher.update(Buffer.from(data, 'hex')),
         decipher.final()
     ])
 


### PR DESCRIPTION
## What & why

The first actual `.js → .ts` conversions, now that #44 (tsx) and #46 (tooling) are both in — thanks for the reviews! Three files in `shared/lib/utils`: `errors.ts`, `constants.ts`, `utilities.ts`. This PR is the template for every conversion that follows, so it's worth reading closely once; the rest will feel like reruns.

## The pattern

1. `git mv foo.js foo.ts` (GitHub then shows a clean rename + small diff, not a delete/add).
2. **Import specifiers don't change** — files importing `'./errors.js'` keep saying `.js`. tsx (at runtime), tsc (type checking), and Vitest all resolve a `.js` specifier to the `.ts` file. That's what makes each conversion local: no ripple through importers.
3. Add types until `npm run typecheck` is clean under `strict: true`, changing behavior not at all.

Highlights of what that looked like here:

- **`constants.ts`** got one meaningful addition: `as const`. Every field name is now a precise literal type (`'fieldNumber'`, not `string`) and readonly — so future typed code gets autocomplete on `fieldNames.*` and typos become compile errors.
- **`utilities.ts`** is where strict mode earned its keep. It flagged two implicit `Date` coercions in `getDayOfYear` (`isNaN(date)` and `date - startDate` — JavaScript quietly converts the Date to a number; TypeScript makes you say `date.getTime()`). Same behavior, now explicit. It also pushed `parseQueryParameters` to declare an honest return type (`ParsedQueryParameters`, including the conditionally-added `error` field), which let the test file delete the type-widening workaround from #46 — that's the loop closing.
- **What I deliberately did *not* do**: fix #45 (it's annotated with a comment instead — conversions shouldn't change behavior, even buggy behavior), and `parseSubtasks` keeps an explicit `any[]` return — its input is client-supplied JSON, and inventing a type for unvalidated data would be false confidence. `any` is allowed when it's honest; strict mode just won't let it happen by accident.

## Where to look first

The `utilities.ts` diff, side by side with the old file — it's the best 80 lines for calibrating "how much do conversions change?" (Answer: signatures and a handful of expressions; logic untouched.)

## How I verified it

- `npm run typecheck` and `npm test` green (31 tests, unchanged).
- `docker compose up --build`: server and worker boot with the `.ts` files bind-mounted — first live proof of tsx resolving `.js` specifiers to `.ts` in the containers.
- Logged in as admin against the running server (200): exercises bcrypt + JWT through `constants.ts` and `errors.ts` end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)